### PR TITLE
Use latest mastermind version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
         "marc1706/fast-image-size": "1.*",
-        "masterminds/html5": "~2.3.0",
+        "masterminds/html5": "^2.3",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },


### PR DESCRIPTION
Test are passing:

```
amp-library on  master via 🐘 v7.3.10 took 31s
➜ vendor/bin/phpunit tests
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

.............................................................     61 / 61 (100%)

Time: 4.48 seconds, Memory: 18.00MB

OK (61 tests, 61 assertions)
```